### PR TITLE
Fix CSS for footer on print

### DIFF
--- a/print.php
+++ b/print.php
@@ -65,7 +65,14 @@
     .firmas p { margin: 4px 0; }
 
     @media print {
-      body { margin: 0; }
+      body { margin: 0; padding-bottom: 120px; }
+      .firmas {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        margin: 0;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak `print.php` print styles so footer stays stuck to bottom of each page

## Testing
- `php -l print.php`

------
https://chatgpt.com/codex/tasks/task_e_6861e1f971348323b7722157051bba60